### PR TITLE
Add Rule #108: Democratic Voting on New Rules Modifications

### DIFF
--- a/players.md
+++ b/players.md
@@ -3,7 +3,7 @@
 Players                   | Points | Vetoes | Title           |
 --------------------------| ------:| ------:| ---------------:|
 Dimitri                   | 0      | 1      | Esquire         |
-player2                   | 0      | 1      | Esquire         |
+Oleg                      | 0      | 1      | Esquire         |
 player3                   | 0      | 1      | Esquire         |
 
 ___

--- a/players.md
+++ b/players.md
@@ -2,7 +2,7 @@
 
 Players                   | Points | Vetoes | Title           |
 --------------------------| ------:| ------:| ---------------:|
-player1                   | 0      | 1      | Esquire         |
+Dimitri                   | 0      | 1      | Esquire         |
 player2                   | 0      | 1      | Esquire         |
 player3                   | 0      | 1      | Esquire         |
 
@@ -19,7 +19,7 @@ ___
 
 
 ### moderators
-- player2
+- Dimitri
 - player3
 
 

--- a/rules.md
+++ b/rules.md
@@ -46,3 +46,9 @@
 >
 > c) The total sum of points may not increase or decrease as a result of this amendment.
 
+
+
+#### 107: Democratic Change in New Rules
+> a) Whenever a new rule is to be elected, all players EXCEPT the one adding the rule must collectively decide on a change in the specific rule.
+>
+> The change(s) in the rule must be relevant to the rule itself, and may not be a completely seperate rule.


### PR DESCRIPTION
**Rules** #108

This new rule adds makes all newfound rules to be reviewed and modified by all players EXCEPT the one which proposes for the rule.